### PR TITLE
Refactor: Correct loop variable typo in input handler

### DIFF
--- a/src/main/kotlin/in/kerv/ddrpad/usbdriver/Main.kt
+++ b/src/main/kotlin/in/kerv/ddrpad/usbdriver/Main.kt
@@ -135,8 +135,8 @@ private fun handleInputChange(
     virtualDdrPad.pressKey(newlyPressedButton.toEventCode())
   }
 
-  for (newlyReleasedButtons in newlyReleasedButtons) {
-    virtualDdrPad.releaseKey(newlyReleasedButtons.toEventCode())
+  for (newlyReleasedButton in newlyReleasedButtons) {
+    virtualDdrPad.releaseKey(newlyReleasedButton.toEventCode())
   }
 }
 


### PR DESCRIPTION
The `handleInputChange` function contained a typo where the loop variable `newlyReleasedButtons` was the same as the collection it was iterating over. This has been corrected to `newlyReleasedButton` for clarity and correctness.